### PR TITLE
DropdownMenu Up-Down Direction Bug Fixed

### DIFF
--- a/es/components/dropdownMenu.js
+++ b/es/components/dropdownMenu.js
@@ -3,15 +3,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _react = _interopRequireDefault(require("react"));
 
 var _Dropdown = _interopRequireDefault(require("react-bootstrap/Dropdown"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -21,13 +21,13 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 var DropdownMenu =
 /*#__PURE__*/
@@ -67,9 +67,9 @@ function (_React$PureComponent) {
       var inputData = this.state.inputData;
       var width = this.props.width || 250;
       var margin = this.props.margin || 0;
-      var direction = "down" || this.props.direction;
+      var direction = this.props.direction || "down";
       var dropdownItems = inputData.map(function (item) {
-        return _react.default.createElement(_Dropdown.default.Item, {
+        return _react["default"].createElement(_Dropdown["default"].Item, {
           key: item,
           onClick: _this2.handleMenuItemClick,
           id: item
@@ -86,12 +86,13 @@ function (_React$PureComponent) {
         maxWidth: "".concat(width, "px"),
         width: "".concat(width, "px")
       };
-      return _react.default.createElement(_Dropdown.default, null, _react.default.createElement(_Dropdown.default.Toggle, {
+      return _react["default"].createElement(_Dropdown["default"], {
+        drop: direction
+      }, _react["default"].createElement(_Dropdown["default"].Toggle, {
         id: "dropdown-basic-button",
         style: dropdownStyle,
-        size: "lg",
-        drop: direction
-      }, this.state.currentTitle), _react.default.createElement(_Dropdown.default.Menu, {
+        size: "lg"
+      }, this.state.currentTitle), _react["default"].createElement(_Dropdown["default"].Menu, {
         style: dropdownMenuStyle
       }, dropdownItems));
     }
@@ -116,9 +117,9 @@ function (_React$PureComponent) {
   }]);
 
   return DropdownMenu;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
-exports.default = DropdownMenu;
+exports["default"] = DropdownMenu;
 DropdownMenu.defaultProps = {
   inputData: ["1"],
   title: "Dropdown Menu"

--- a/src/components/dropdownMenu.js
+++ b/src/components/dropdownMenu.js
@@ -45,7 +45,7 @@ export default class DropdownMenu extends React.PureComponent {
 		let inputData = this.state.inputData;
 		let width = this.props.width || 250;
 		let margin = this.props.margin || 0;
-		let direction = "down" || this.props.direction;
+		let direction = this.props.direction || "down";
 		let dropdownItems = inputData.map(item => (
 			<Dropdown.Item key={item} onClick={this.handleMenuItemClick} id={item}>
 				{item}
@@ -63,12 +63,11 @@ export default class DropdownMenu extends React.PureComponent {
 			width: `${width}px`
 		};
 		return (
-			<Dropdown>
+			<Dropdown drop={direction}>
 				<Dropdown.Toggle
 					id="dropdown-basic-button"
 					style={dropdownStyle}
 					size="lg"
-					drop={direction}
 				>
 					{this.state.currentTitle}
 				</Dropdown.Toggle>


### PR DESCRIPTION
1. As written in React-Bootstrap documentation (https://react-bootstrap.github.io/components/dropdowns/#dropdown-props), `drop` prop should be defined in `Dropdown` component instead of `Dropdown.Toggle`. Otherwise, no effect even if the `drop` prop is set other than the default value.

2. This line always overrides direction as "down": https://github.com/WU-BIMAC/4DNMicroscopyMetadataToolReact/blob/62bce0e16f89947e99c26441a51bccd97c2e7f31/src/components/dropdownMenu.js#L48

Instead, `let direction = this.props.direction || "down";` is correct IMHO.


We need this fix since If `4DNMicroscopyMetadataToolReact` is embedded and there is a space between Micrometa's footer and window bottom side, then dropdown popup direction is down but parent hides the popup. (see screencast below, try to click save button on footer)

https://i.gyazo.com/09ea086276dc602ae5654edf6245f134.gif
